### PR TITLE
DISPATCH-1502: directly pass a copy of the string 

### DIFF
--- a/src/router_core/route_tables.c
+++ b/src/router_core/route_tables.c
@@ -756,25 +756,21 @@ static void qdr_unsubscribe_CT(qdr_core_t *core, qdr_action_t *action, bool disc
 
 static void qdr_do_mobile_added(qdr_core_t *core, qdr_general_work_t *work)
 {
-    char *address_hash = qdr_field_copy(work->field);
+    char *address_hash = work->field;
     if (address_hash) {
         core->rt_mobile_added(core->rt_context, address_hash, work->treatment);
         free(address_hash);
     }
-
-    qdr_field_free(work->field);
 }
 
 
 static void qdr_do_mobile_removed(qdr_core_t *core, qdr_general_work_t *work)
 {
-    char *address_hash = qdr_field_copy(work->field);
+    char *address_hash = work->field;
     if (address_hash) {
         core->rt_mobile_removed(core->rt_context, address_hash);
         free(address_hash);
     }
-
-    qdr_field_free(work->field);
 }
 
 
@@ -787,7 +783,7 @@ static void qdr_do_link_lost(qdr_core_t *core, qdr_general_work_t *work)
 void qdr_post_mobile_added_CT(qdr_core_t *core, const char *address_hash, qd_address_treatment_t treatment)
 {
     qdr_general_work_t *work = qdr_general_work(qdr_do_mobile_added);
-    work->field = qdr_field(address_hash);
+    work->field = strdup(address_hash);
     work->treatment = treatment;
     qdr_post_general_work_CT(core, work);
 }
@@ -796,7 +792,7 @@ void qdr_post_mobile_added_CT(qdr_core_t *core, const char *address_hash, qd_add
 void qdr_post_mobile_removed_CT(qdr_core_t *core, const char *address_hash)
 {
     qdr_general_work_t *work = qdr_general_work(qdr_do_mobile_removed);
-    work->field = qdr_field(address_hash);
+    work->field = strdup(address_hash);
     qdr_post_general_work_CT(core, work);
 }
 
@@ -807,5 +803,3 @@ void qdr_post_link_lost_CT(qdr_core_t *core, int link_maskbit)
     work->maskbit = link_maskbit;
     qdr_post_general_work_CT(core, work);
 }
-
-

--- a/src/router_core/router_core_private.h
+++ b/src/router_core/router_core_private.h
@@ -231,7 +231,7 @@ typedef void (*qdr_general_work_handler_t) (qdr_core_t *core, qdr_general_work_t
 struct qdr_general_work_t {
     DEQ_LINKS(qdr_general_work_t);
     qdr_general_work_handler_t   handler;
-    qdr_field_t                 *field;
+    char                        *field;
     int                          maskbit;
     int                          inter_router_cost;
     qd_message_t                *msg;


### PR DESCRIPTION
...rather than qdr_field_t/qdr_iterator_t/qd_buffer_t combination

In the case where the pool does not have sufficient objects, this significantly reduces the extra memory required
to handle the disconnection of links triggering unmapping of addresses. However it does mean that every map/unmap
would involve at least one allocation.