### PR TITLE
Tcp buffering cr1 - asan result only - DO NOT MERGE

### DIFF
--- a/ASAN-INTA-1.out
+++ b/ASAN-INTA-1.out
@@ -1,0 +1,81 @@
+=================================================================
+==3050006==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x62d000170400 at pc 0x7fa4d55c071e bp 0x7fa4bee20dd0 sp 0x7fa4bee20578
+WRITE of size 512 at 0x62d000170400 thread T3
+    #0 0x7fa4d55c071d in __interceptor_memcpy (/lib64/libasan.so.6+0x3a71d)
+    #1 0x7fa4d4ba82b9 in copy_outgoing_buffs /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:579
+    #2 0x7fa4d4ba91e3 in handle_outgoing /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:618
+    #3 0x7fa4d4bac20b in handle_connection_event /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:810
+    #4 0x7fa4d4df4291 in handle_event_with_context /home/chug/git/qpid-dispatch/src/server.c:802
+    #5 0x7fa4d4df42d2 in do_handle_raw_connection_event /home/chug/git/qpid-dispatch/src/server.c:808
+    #6 0x7fa4d4df8893 in handle /home/chug/git/qpid-dispatch/src/server.c:1089
+    #7 0x7fa4d4df8b54 in thread_run /home/chug/git/qpid-dispatch/src/server.c:1121
+    #8 0x7fa4d4c7e96b in _thread_init /home/chug/git/qpid-dispatch/src/posix/threading.c:172
+    #9 0x7fa4d4564431 in start_thread /usr/src/debug/glibc-2.31-74-gd0c84d22b6/nptl/pthread_create.c:477
+    #10 0x7fa4d371f6d2 in __clone (/lib64/libc.so.6+0x1016d2)
+
+0x62d000170400 is located 0 bytes to the right of 32768-byte region [0x62d000168400,0x62d000170400)
+allocated by thread T4 here:
+    #0 0x7fa4d5636667 in __interceptor_malloc (/lib64/libasan.so.6+0xb0667)
+    #1 0x7fa4d4ba02de in allocate_tcp_write_buffer /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:147
+    #2 0x7fa4d4bafaee in qdr_tcp_connection_egress /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:1025
+    #3 0x7fa4d4bb7191 in qdr_tcp_deliver /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:1414
+    #4 0x7fa4d4d80326 in qdr_link_process_deliveries /home/chug/git/qpid-dispatch/src/router_core/transfer.c:178
+    #5 0x7fa4d4bb693b in qdr_tcp_push /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:1392
+    #6 0x7fa4d4cb9a83 in qdr_connection_process /home/chug/git/qpid-dispatch/src/router_core/connections.c:414
+    #7 0x7fa4d4ba0bca in on_activate /home/chug/git/qpid-dispatch/src/adaptors/tcp_adaptor.c:179
+    #8 0x7fa4d4e085be in qd_timer_visit /home/chug/git/qpid-dispatch/src/timer.c:317
+    #9 0x7fa4d4df6ecc in handle /home/chug/git/qpid-dispatch/src/server.c:1006
+    #10 0x7fa4d4df8b54 in thread_run /home/chug/git/qpid-dispatch/src/server.c:1121
+    #11 0x7fa4d4c7e96b in _thread_init /home/chug/git/qpid-dispatch/src/posix/threading.c:172
+    #12 0x7fa4d4564431 in start_thread /usr/src/debug/glibc-2.31-74-gd0c84d22b6/nptl/pthread_create.c:477
+
+Thread T3 created by T0 here:
+    #0 0x7fa4d55ddbe5 in __interceptor_pthread_create (/lib64/libasan.so.6+0x57be5)
+    #1 0x7fa4d4c7ead6 in sys_thread /home/chug/git/qpid-dispatch/src/posix/threading.c:181
+    #2 0x7fa4d4dfffbd in qd_server_run /home/chug/git/qpid-dispatch/src/server.c:1499
+    #3 0x4026f8 in main_process /home/chug/git/qpid-dispatch/router/src/main.c:115
+    #4 0x404578 in main /home/chug/git/qpid-dispatch/router/src/main.c:369
+    #5 0x7fa4d3645081 in __libc_start_main ../csu/libc-start.c:308
+
+Thread T4 created by T0 here:
+    #0 0x7fa4d55ddbe5 in __interceptor_pthread_create (/lib64/libasan.so.6+0x57be5)
+    #1 0x7fa4d4c7ead6 in sys_thread /home/chug/git/qpid-dispatch/src/posix/threading.c:181
+    #2 0x7fa4d4dfffbd in qd_server_run /home/chug/git/qpid-dispatch/src/server.c:1499
+    #3 0x4026f8 in main_process /home/chug/git/qpid-dispatch/router/src/main.c:115
+    #4 0x404578 in main /home/chug/git/qpid-dispatch/router/src/main.c:369
+    #5 0x7fa4d3645081 in __libc_start_main ../csu/libc-start.c:308
+
+SUMMARY: AddressSanitizer: heap-buffer-overflow (/lib64/libasan.so.6+0x3a71d) in __interceptor_memcpy
+Shadow bytes around the buggy address:
+  0x0c5a80026030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c5a80026040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c5a80026050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c5a80026060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+  0x0c5a80026070: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+=>0x0c5a80026080:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c5a80026090: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c5a800260a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c5a800260b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c5a800260c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+  0x0c5a800260d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
+Shadow byte legend (one shadow byte represents 8 application bytes):
+  Addressable:           00
+  Partially addressable: 01 02 03 04 05 06 07 
+  Heap left redzone:       fa
+  Freed heap region:       fd
+  Stack left redzone:      f1
+  Stack mid redzone:       f2
+  Stack right redzone:     f3
+  Stack after return:      f5
+  Stack use after scope:   f8
+  Global redzone:          f9
+  Global init order:       f6
+  Poisoned by user:        f7
+  Container overflow:      fc
+  Array cookie:            ac
+  Intra object redzone:    bb
+  ASan internal:           fe
+  Left alloca redzone:     ca
+  Right alloca redzone:    cb
+  Shadow gap:              cc
+==3050006==ABORTING

--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -383,6 +383,16 @@ size_t qd_message_stream_data_payload_length(const qd_message_stream_data_t *str
 void qd_message_stream_data_release(qd_message_stream_data_t *stream_data);
 
 
+/**
+ * qd_message_stream_data_release_up_to
+ *
+ * Release this stream data and all the previous ones also.
+ *
+ * @param stream_data Pointer to a body data object returned by qd_message_next_stream_data
+ */
+void qd_message_stream_data_release_up_to(qd_message_stream_data_t *stream_data);
+
+
 typedef enum {
     QD_MESSAGE_STREAM_DATA_BODY_OK,      // A valid body data object has been returned
     QD_MESSAGE_STREAM_DATA_FOOTER_OK,    // A valid footer has been returned

--- a/src/adaptors/tcp_adaptor.c
+++ b/src/adaptors/tcp_adaptor.c
@@ -46,12 +46,12 @@
 //   arrives:
 //
 const uint32_t TCP_MAX_CAPACITY = 121635 * 6 * 2;
+const size_t TCP_BUFFER_SIZE = 16384*2;
 
 ALLOC_DEFINE(qd_tcp_listener_t);
 ALLOC_DEFINE(qd_tcp_connector_t);
 
-#define READ_BUFFERS 4
-#define WRITE_BUFFERS 4
+#define WRITE_BUFFERS 12
 
 typedef struct qdr_tcp_connection_t qdr_tcp_connection_t;
 
@@ -91,9 +91,15 @@ struct qdr_tcp_connection_t {
     uint64_t              last_in_time;
     uint64_t              last_out_time;
 
-    qd_message_stream_data_t *outgoing_stream_data;   // current segment
+    qd_message_stream_data_t *previous_stream_data; // previous segment (received in full)
+    qd_message_stream_data_t *outgoing_stream_data; // current segment
     size_t                  outgoing_body_bytes;  // bytes received from current segment
     int                     outgoing_body_offset; // buffer offset into current segment
+
+    pn_raw_buffer_t         read_buffer;
+    bool                    read_pending;
+    pn_raw_buffer_t         write_buffer;
+    bool                    write_pending;
 
     pn_raw_buffer_t         outgoing_buffs[WRITE_BUFFERS];
     int                     outgoing_buff_count;  // number of buffers with data
@@ -126,6 +132,24 @@ static void qdr_del_tcp_connection_CT(qdr_core_t *core, qdr_action_t *action, bo
 static void handle_disconnected(qdr_tcp_connection_t* conn);
 static void free_qdr_tcp_connection(qdr_tcp_connection_t* conn);
 static void qdr_tcp_open_server_side_connection(qdr_tcp_connection_t* tc);
+
+static void allocate_tcp_buffer(pn_raw_buffer_t *buffer)
+{
+    buffer->bytes = malloc(TCP_BUFFER_SIZE);
+    ZERO(buffer->bytes);
+    buffer->capacity = TCP_BUFFER_SIZE;
+    buffer->size = 0;
+    buffer->offset = 0;
+}
+
+static void allocate_tcp_write_buffer(pn_raw_buffer_t *buffer)
+{
+    buffer->bytes = malloc(TCP_BUFFER_SIZE);
+    ZERO(buffer->bytes);
+    buffer->capacity = TCP_BUFFER_SIZE;
+    buffer->size = 0;
+    buffer->offset = 0;
+}
 
 static inline uint64_t qdr_tcp_conn_linkid(const qdr_tcp_connection_t *conn)
 {
@@ -163,28 +187,14 @@ static void on_activate(void *context)
 
 static void grant_read_buffers(qdr_tcp_connection_t *conn)
 {
-    if (conn->raw_closed_read)
+    if (conn->raw_closed_read || conn->read_pending)
         return;
 
-    pn_raw_buffer_t raw_buffers[READ_BUFFERS];
-    // Give proactor more read buffers for the socket
-    size_t desired = pn_raw_connection_read_buffers_capacity(conn->pn_raw_conn);
+    conn->read_pending = true;
     qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
-        "[C%"PRIu64"][L%"PRIu64"] Granting %zu to pn_raw_connection_give_read_buffers()",
-        conn->conn_id, conn->incoming_id, desired);
-    while (desired) {
-        size_t i;
-        for (i = 0; i < desired && i < READ_BUFFERS; ++i) {
-            qd_buffer_t *buf = qd_buffer();
-            raw_buffers[i].bytes = (char*) qd_buffer_base(buf);
-            raw_buffers[i].capacity = qd_buffer_capacity(buf);
-            raw_buffers[i].size = 0;
-            raw_buffers[i].offset = 0;
-            raw_buffers[i].context = (uintptr_t) buf;
-        }
-        desired -= i;
-        pn_raw_connection_give_read_buffers(conn->pn_raw_conn, raw_buffers, i);
-    }
+        "[C%"PRIu64"][L%"PRIu64"] Calling pn_raw_connection_give_read_buffers() capacity=%i offset=%i",
+           conn->conn_id, conn->incoming_id, conn->read_buffer.capacity, conn->read_buffer.offset);
+    pn_raw_connection_give_read_buffers(conn->pn_raw_conn, &conn->read_buffer, 1);
 }
 
 
@@ -216,59 +226,39 @@ void qdr_tcp_q2_unblocked_handler(const qd_alloc_safe_ptr_t context)
     sys_mutex_unlock(tc->activation_lock);
 }
 
-
 // Extract buffers and their bytes from raw connection.
-// * Proton decides how many buffers are to be taken.
-// * Buffers with no data are freed.
-// * Buffers with data are appended to caller's buffers list.
 // * Add received byte count to connection stats
 // * Return the count of bytes in the buffers list
 static int handle_incoming_raw_read(qdr_tcp_connection_t *conn, qd_buffer_list_t *buffers)
 {
-    pn_raw_buffer_t raw_buffers[READ_BUFFERS];
-
-    size_t n;
-    int count = 0;
-    int free_count = 0;
-    const bool was_open = conn->bytes_unacked < TCP_MAX_CAPACITY;
-
-    while ((conn->raw_closed_write || count + conn->bytes_unacked < TCP_MAX_CAPACITY)
-           && (n = pn_raw_connection_take_read_buffers(conn->pn_raw_conn, raw_buffers, READ_BUFFERS)) ) {
-
-        for (size_t i = 0; i < n && raw_buffers[i].bytes; ++i) {
-            qd_buffer_t *buf = (qd_buffer_t*) raw_buffers[i].context;
-            qd_buffer_insert(buf, raw_buffers[i].size);
-            count += raw_buffers[i].size;
-
-            assert(raw_buffers[i].size == qd_buffer_size(buf));
-            if (raw_buffers[i].size > 0) {
-                DEQ_INSERT_TAIL(*buffers, buf);
-            } else {
-                qd_buffer_free(buf);
-                free_count++;
-            }
-        }
+    pn_raw_buffer_t raw_buffer;
+    if ( conn->bytes_unacked >= TCP_MAX_CAPACITY || !pn_raw_connection_take_read_buffers(conn->pn_raw_conn, &raw_buffer, 1)) {
+        return 0;
     }
+    int result = raw_buffer.size;
+    qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
+        "[C%"PRIu64"] pn_raw_connection_take_read_buffers() took buffer with %zu bytes",
+        conn->conn_id, result);
 
-    if (count > 0) {
+    if (buffers) {
+        qd_buffer_list_append(buffers, (uint8_t*) (raw_buffer.bytes + raw_buffer.offset), raw_buffer.size);
+    }
+    //reset buffer for further reads
+    conn->read_buffer.size = 0;
+    conn->read_buffer.offset = 0;
+    conn->read_pending = false;
+    if (result > 0) {
         // account for any incoming bytes just read
         conn->last_in_time = tcp_adaptor->core->uptime_ticks;
-        conn->bytes_in      += count;
-        conn->bytes_unacked += count;
+        conn->bytes_in      += result;
+        conn->bytes_unacked += result;
         if (conn->bytes_unacked >= TCP_MAX_CAPACITY) {
-            if (was_open) {
-                qd_log(tcp_adaptor->log_source, QD_LOG_TRACE,
-                       "[C%"PRIu64"] TCP RX window CLOSED: bytes in=%"PRIu64" unacked=%"PRIu64,
-                       conn->conn_id, conn->bytes_in, conn->bytes_unacked);
-            }
+            qd_log(tcp_adaptor->log_source, QD_LOG_TRACE,
+                   "[C%"PRIu64"] TCP RX window CLOSED: bytes in=%"PRIu64" unacked=%"PRIu64,
+                   conn->conn_id, conn->bytes_in, conn->bytes_unacked);
         }
     }
-
-    qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
-        "[C%"PRIu64"] pn_raw_connection_take_read_buffers() took %zu, freed %i",
-        conn->conn_id, DEQ_SIZE(*buffers), free_count);
-
-    return count;
+    return result;
 }
 
 
@@ -292,10 +282,7 @@ static int handle_incoming(qdr_tcp_connection_t *conn, const char *msg)
             "[C%"PRIu64"][L%"PRIu64"] handle_incoming %s for %s connection. drain read buffers",
             conn->conn_id, conn->incoming_id, msg,
             qdr_tcp_connection_role_name(conn));
-        qd_buffer_list_t buffers;
-        DEQ_INIT(buffers);
-        handle_incoming_raw_read(conn, &buffers);
-        qd_buffer_list_free_buffers(&buffers);
+        handle_incoming_raw_read(conn, 0);
         return 0;
     }
 
@@ -500,6 +487,8 @@ static void handle_disconnected(qdr_tcp_connection_t* conn)
         qdr_connection_closed(conn->qdr_conn);
         conn->qdr_conn = 0;
     }
+    free(conn->write_buffer.bytes);
+    free(conn->read_buffer.bytes);
 
     //need to free on core thread to avoid deleting while in use by management agent
     qdr_action_t *action = qdr_action(qdr_del_tcp_connection_CT, "delete_tcp_connection");
@@ -554,13 +543,9 @@ static int read_message_body(qdr_tcp_connection_t *conn, qd_message_t *msg, pn_r
         assert(conn->outgoing_body_bytes <= conn->outgoing_stream_data->payload.length);
 
         if (conn->outgoing_body_bytes == conn->outgoing_stream_data->payload.length) {
-            // This buffer set consumes the remainder of the stream_data segment.
-            // Attach the stream_data struct to the last buffer so that the struct
-            // can be freed after the buffer has been transmitted by raw connection out.
-            buffers[used-1].context = (uintptr_t) conn->outgoing_stream_data;
-
             // Erase the stream_data struct from the connection so that
             // a new one gets created on the next pass.
+            conn->previous_stream_data = conn->outgoing_stream_data;
             conn->outgoing_stream_data = 0;
         } else {
             // Returned buffer set did not consume the entire stream_data segment.
@@ -576,7 +561,7 @@ static int read_message_body(qdr_tcp_connection_t *conn, qd_message_t *msg, pn_r
 }
 
 
-static bool write_outgoing_buffs(qdr_tcp_connection_t *conn)
+static bool copy_outgoing_buffs(qdr_tcp_connection_t *conn)
 {
     // Send the outgoing buffs to pn_raw_conn.
     // Return true if all the buffers went out.
@@ -584,24 +569,22 @@ static bool write_outgoing_buffs(qdr_tcp_connection_t *conn)
 
     if (conn->outgoing_buff_count == 0) {
         result = true;
+    } else if (conn->write_pending) {
+        qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG, "[C%"PRIu64"] Can't write, previous write still pending", conn->conn_id);
+        result = false;
     } else {
-        size_t used = pn_raw_connection_write_buffers(conn->pn_raw_conn,
-                                                      &conn->outgoing_buffs[conn->outgoing_buff_idx],
-                                                      conn->outgoing_buff_count);
-        result = used == conn->outgoing_buff_count;
-
-        int bytes_written = 0;
-        for (size_t i = 0; i < used; i++) {
-            if (conn->outgoing_buffs[conn->outgoing_buff_idx + i].bytes) {
-                bytes_written += conn->outgoing_buffs[conn->outgoing_buff_idx + i].size;
-            } else {
-                qd_log(tcp_adaptor->log_source, QD_LOG_ERROR,
-                       "[C%"PRIu64"] empty buffer can't be written (%"PRIu64" of %"PRIu64")",
-                       conn->conn_id, i+1, used);
-            }
+        //copy small buffers into large one
+        size_t used = 0;
+        while (used < conn->outgoing_buff_count && conn->write_buffer.size < conn->write_buffer.capacity) {
+            memcpy(conn->write_buffer.bytes + conn->write_buffer.size, conn->outgoing_buffs[used].bytes, conn->outgoing_buffs[used].size);
+            conn->write_buffer.size += conn->outgoing_buffs[used].size;
+            qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
+                   "[C%"PRIu64"] Copying buffer %i of %i with %i bytes (total=%i)", conn->conn_id, used+1, conn->outgoing_buff_count, conn->outgoing_buffs[used].size, conn->write_buffer.size);
+            used++;
         }
-        qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
-               "[C%"PRIu64"] pn_raw_connection_write_buffers wrote %i bytes", conn->conn_id, bytes_written);
+        conn->write_buffer.context = (uintptr_t) conn->previous_stream_data;
+
+        result = used == conn->outgoing_buff_count;
 
         conn->outgoing_buff_count -= used;
         conn->outgoing_buff_idx   += used;
@@ -623,7 +606,7 @@ static void handle_outgoing(qdr_tcp_connection_t *conn)
 
         if (conn->outgoing_buff_count > 0) {
             // flush outgoing buffs that hold body data waiting to go out
-            read_more_body = write_outgoing_buffs(conn);
+            read_more_body = copy_outgoing_buffs(conn);
         }
         while (read_more_body) {
             ZERO(conn->outgoing_buffs);
@@ -632,10 +615,23 @@ static void handle_outgoing(qdr_tcp_connection_t *conn)
 
             if (conn->outgoing_buff_count > 0) {
                 // Send the data just returned
-                read_more_body = write_outgoing_buffs(conn);
+                read_more_body = copy_outgoing_buffs(conn);
             } else {
                 // The incoming stream has no new data to send
                 break;
+            }
+        }
+
+        if (conn->write_buffer.size && !conn->write_pending) {
+            if (pn_raw_connection_write_buffers(conn->pn_raw_conn, &conn->write_buffer, 1)) {
+                qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
+                       "[C%"PRIu64"] pn_raw_connection_write_buffers wrote %i bytes", conn->conn_id, conn->write_buffer.size);
+
+                conn->previous_stream_data = 0;
+                conn->write_pending = true;
+            } else {
+                qd_log(tcp_adaptor->log_source, QD_LOG_DEBUG,
+                       "[C%"PRIu64"] pn_raw_connection_write_buffers could not write %i bytes", conn->conn_id, conn->write_buffer.size);
             }
         }
 
@@ -678,6 +674,8 @@ static char *get_address_string(pn_raw_connection_t *socket)
 
 static void qdr_tcp_connection_ingress_accept(qdr_tcp_connection_t* tc)
 {
+    allocate_tcp_write_buffer(&tc->write_buffer);
+    allocate_tcp_buffer(&tc->read_buffer);
     tc->remote_address = get_address_string(tc->pn_raw_conn);
     tc->global_id = get_global_id(tc->config.site_id, tc->remote_address);
     qdr_connection_info_t *info = qdr_connection_info(false,               // is_encrypted,
@@ -856,40 +854,40 @@ static void handle_connection_event(pn_event_t *e, qd_server_t *qd_server, void 
         break;
     }
     case PN_RAW_CONNECTION_WRITTEN: {
-        pn_raw_buffer_t buffs[WRITE_BUFFERS];
-        size_t n;
-        size_t written = 0;
-        while ( (n = pn_raw_connection_take_written_buffers(conn->pn_raw_conn, buffs, WRITE_BUFFERS)) ) {
-            for (size_t i = 0; i < n; ++i) {
-                written += buffs[i].size;
-                if (buffs[i].context) {
-                    qd_message_stream_data_release((qd_message_stream_data_t*) buffs[i].context);
-                }
+        pn_raw_buffer_t buff;
+        if ( pn_raw_connection_take_written_buffers(conn->pn_raw_conn, &buff, 1) ) {
+            size_t written = buff.size;
+            if (buff.context) {
+                qd_message_stream_data_release_up_to((qd_message_stream_data_t*) buff.context);
             }
-        }
-        conn->last_out_time = tcp_adaptor->core->uptime_ticks;
-        conn->bytes_out += written;
+            conn->write_pending = false;
+            conn->write_buffer.size = 0;
+            conn->write_buffer.offset = 0;
+            conn->write_buffer.context = 0;
+            conn->last_out_time = tcp_adaptor->core->uptime_ticks;
+            conn->bytes_out += written;
 
-        if (written > 0) {
-            // Tell the upstream to open its receive window.  Note: this update
-            // is sent to the upstream (ingress) TCP adaptor. Since this update
-            // is internal to the router network (never sent to the client) we
-            // do not need to use the section_number (no section numbers in a
-            // TCP stream!) and use section_offset only.
-            //
-            qd_delivery_state_t *dstate = qd_delivery_state();
-            dstate->section_number = 0;
-            dstate->section_offset = conn->bytes_out;
-            qdr_delivery_remote_state_updated(tcp_adaptor->core, conn->outstream,
-                                              PN_RECEIVED,
-                                              false,  // settled
-                                              dstate,
-                                              false);
-        }
+            if (written > 0) {
+                // Tell the upstream to open its receive window.  Note: this update
+                // is sent to the upstream (ingress) TCP adaptor. Since this update
+                // is internal to the router network (never sent to the client) we
+                // do not need to use the section_number (no section numbers in a
+                // TCP stream!) and use section_offset only.
+                //
+                qd_delivery_state_t *dstate = qd_delivery_state();
+                dstate->section_number = 0;
+                dstate->section_offset = conn->bytes_out;
+                qdr_delivery_remote_state_updated(tcp_adaptor->core, conn->outstream,
+                                                  PN_RECEIVED,
+                                                  false,  // settled
+                                                  dstate,
+                                                  false);
+            }
 
-        qd_log(log, QD_LOG_DEBUG,
-               "[C%"PRIu64"] PN_RAW_CONNECTION_WRITTEN %s pn_raw_connection_take_written_buffers wrote %zu bytes. Total written %"PRIu64" bytes",
-               conn->conn_id, qdr_tcp_connection_role_name(conn), written, conn->bytes_out);
+            qd_log(log, QD_LOG_DEBUG,
+                   "[C%"PRIu64"] PN_RAW_CONNECTION_WRITTEN %s pn_raw_connection_take_written_buffers wrote %zu bytes. Total written %"PRIu64" bytes",
+                   conn->conn_id, qdr_tcp_connection_role_name(conn), written, conn->bytes_out);
+        }
         while (qdr_connection_process(conn->qdr_conn)) {}
         break;
     }
@@ -1024,6 +1022,8 @@ static qdr_tcp_connection_t *qdr_tcp_connection_egress(qd_bridge_config_t *confi
     if (tc->egress_dispatcher)
         qdr_tcp_open_server_side_connection(tc);
     else {
+        allocate_tcp_write_buffer(&tc->write_buffer);
+        allocate_tcp_buffer(&tc->read_buffer);
         qd_log(tcp_adaptor->log_source, QD_LOG_INFO,
                "[C%"PRIu64"] call pn_proactor_raw_connect(). Egress connecting to: %s",
                tc->conn_id, tc->config.host_port);

--- a/src/message.c
+++ b/src/message.c
@@ -2578,6 +2578,20 @@ int qd_message_stream_data_buffers(qd_message_stream_data_t *stream_data, pn_raw
     return idx;
 }
 
+void qd_message_stream_data_release_up_to(qd_message_stream_data_t *stream_data)
+{
+    if (!stream_data)
+        return;
+
+    qd_message_pvt_t         *msg     = stream_data->owning_message;
+    qd_message_stream_data_t *next    = DEQ_HEAD(msg->stream_data_list);
+    qd_message_stream_data_t *current = NULL;
+    while (next && current != stream_data) {
+        current = next;
+        next = DEQ_NEXT(next);
+        qd_message_stream_data_release(current);
+    }
+}
 
 /**
  * qd_message_stream_data_release

--- a/tests/system_tests_tcp_adaptor.py
+++ b/tests/system_tests_tcp_adaptor.py
@@ -742,7 +742,7 @@ class TcpAdaptor(TestCase):
     # Tests run by ctest
     #
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_01_tcp_basic_connectivity(self):
+    def xtest_01_tcp_basic_connectivity(self):
         """
         Echo a series of 1-byte messages, one at a time, to prove general connectivity.
         Every listener is tried. Proves every router can forward to servers on
@@ -762,7 +762,7 @@ class TcpAdaptor(TestCase):
 
     # larger messages
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_10_tcp_INTA_INTA_100(self):
+    def xtest_10_tcp_INTA_INTA_100(self):
         name = "test_10_tcp_INTA_INTA_100"
         self.logger.log("TCP_TEST Start %s" % name)
         pairs = [self.EchoPair(self.INTA, self.INTA, sizes=[100])]
@@ -774,7 +774,7 @@ class TcpAdaptor(TestCase):
         self.logger.log("TCP_TEST Stop %s SUCCESS" % name)
 
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_11_tcp_INTA_INTA_1000(self):
+    def xtest_11_tcp_INTA_INTA_1000(self):
         name = "test_11_tcp_INTA_INTA_1000"
         self.logger.log("TCP_TEST Start %s" % name)
         pairs = [self.EchoPair(self.INTA, self.INTA, sizes=[1000])]
@@ -798,7 +798,7 @@ class TcpAdaptor(TestCase):
         self.logger.log("TCP_TEST Stop %s SUCCESS" % name)
 
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_13_tcp_EA1_EC2_500000(self):
+    def xtest_13_tcp_EA1_EC2_500000(self):
         name = "test_12_tcp_EA1_EC2_500000"
         self.logger.log("TCP_TEST Start %s" % name)
         pairs = [self.EchoPair(self.INTA, self.INTA, sizes=[500000])]
@@ -809,7 +809,7 @@ class TcpAdaptor(TestCase):
         assert result is None, "TCP_TEST Stop %s FAIL: %s" % (name, result)
 
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_20_tcp_connect_disconnect(self):
+    def xtest_20_tcp_connect_disconnect(self):
         name = "test_20_tcp_connect_disconnect"
         self.logger.log("TCP_TEST Start %s" % name)
         pairs = [self.EchoPair(self.INTA, self.INTA, sizes=[0])]
@@ -823,7 +823,7 @@ class TcpAdaptor(TestCase):
 
     # concurrent messages
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_50_concurrent(self):
+    def xtest_50_concurrent(self):
         name = "test_50_concurrent_AtoA_BtoB"
         self.logger.log("TCP_TEST Start %s" % name)
         pairs = [self.EchoPair(self.INTA, self.INTA),
@@ -837,7 +837,7 @@ class TcpAdaptor(TestCase):
 
     # Q2 holdoff
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_60_q2_holdoff(self):
+    def xtest_60_q2_holdoff(self):
         # for now, Q2 is disabled to avoid stalling TCP backpressure
         self.skipTest("Q2 is disabled on TCP adaptor")
         name = "test_60_q2_holdoff"
@@ -916,7 +916,7 @@ class TcpAdaptorManagementTest(TestCase):
         assert cls.echo_server.is_running
 
     @SkipIfNeeded(DISABLE_SELECTOR_TESTS, DISABLE_SELECTOR_REASON)
-    def test_01_mgmt(self):
+    def xtest_01_mgmt(self):
         """
         Create and delete TCP connectors and listeners
         """


### PR DESCRIPTION
This PR has two objectives:

1. Shorten up the tcp adaptor self tests. Run only a test that fails routinely. Use this commit as a convenience.
2. Include a typical asan error complaint. This commit is info only and the text in this PR is all it can/will ever be.

There are issues with buffer boundaries in the tcp-buffering branch. 

- Asan detects read and write buffer addressing errors. 
- Self test echo server logs show 0x99 (freed memory) bytes being sent TO the echo server
