### PR TITLE
Improvements for tcp buffering

### DIFF
--- a/include/qpid/dispatch/message.h
+++ b/include/qpid/dispatch/message.h
@@ -383,6 +383,16 @@ size_t qd_message_stream_data_payload_length(const qd_message_stream_data_t *str
 void qd_message_stream_data_release(qd_message_stream_data_t *stream_data);
 
 
+/**
+ * qd_message_stream_data_release_up_to
+ *
+ * Release this stream data and all the previous ones also.
+ *
+ * @param stream_data Pointer to a body data object returned by qd_message_next_stream_data
+ */
+void qd_message_stream_data_release_up_to(qd_message_stream_data_t *stream_data);
+
+
 typedef enum {
     QD_MESSAGE_STREAM_DATA_BODY_OK,      // A valid body data object has been returned
     QD_MESSAGE_STREAM_DATA_FOOTER_OK,    // A valid footer has been returned

--- a/src/message.c
+++ b/src/message.c
@@ -2578,6 +2578,20 @@ int qd_message_stream_data_buffers(qd_message_stream_data_t *stream_data, pn_raw
     return idx;
 }
 
+void qd_message_stream_data_release_up_to(qd_message_stream_data_t *stream_data)
+{
+    if (!stream_data)
+        return;
+
+    qd_message_pvt_t         *msg     = stream_data->owning_message;
+    qd_message_stream_data_t *next    = DEQ_HEAD(msg->stream_data_list);
+    qd_message_stream_data_t *current = NULL;
+    while (next && current != stream_data) {
+        current = next;
+        next = DEQ_NEXT(next);
+        qd_message_stream_data_release(current);
+    }
+}
 
 /**
  * qd_message_stream_data_release


### PR DESCRIPTION
* Allow little buffer copy that completely fills big buffer.
* Preserve stream_data object while there is still data to be copied
  from its buffers. Prevents stream_data free that in turn frees
  message qd_buffers that still need to be copied.
This PR fixes all the self-test issues on my Fedora 32 x86_64 dev system.